### PR TITLE
dont fail on funky ids and fix negative value checks

### DIFF
--- a/R/class-AbundanceData.R
+++ b/R/class-AbundanceData.R
@@ -3,18 +3,21 @@ check_abundance_data <- function(object) {
     df <- object@data
     record_id_col <- object@recordIdColumn
     ancestor_id_cols <- object@ancestorIdColumns
+    allIdColumns <- c(record_id_col, ancestor_id_cols)
 
-    if (any(df < 0, na.rm=TRUE)) {
+    if (any(df[, -..allIdColumns] < 0, na.rm=TRUE)) {
       # Find negative values in df and return them for easier debugging.
       negative_indices <- which(df < 0, arr.ind = TRUE)
-      print(negative_indices)
+      row_indices <- unique(negative_indices[, 1])
+      col_indices <- unique(negative_indices[, 2])
+      negative_values <- unlist(lapply(seq_along(negative_indices[, 1]), function(i) dt[negative_indices[i, 1], negative_indices[i, 2], with=FALSE]))
 
       msg <- paste("Abundance data cannot contain negative values. Found negative values in the following samples: ", 
-        paste(df[[record_id_col]][negative_indices[, 2]], collapse = ", "),
+        paste(df[[record_id_col]][row_indices], collapse = ", "),
         " and in the following columns: ",
-        paste(colnames(df)[negative_indices[, 1]], collapse = ", "),
+        paste(colnames(df)[col_indices], collapse = ", "),
         ". The values are: ",
-        paste(df[negative_indices], collapse = ", ")
+        paste(negative_values, collapse = ", ")
       )
       errors <- c(errors, msg)
     }

--- a/tests/testthat/test-AbundanceData.R
+++ b/tests/testthat/test-AbundanceData.R
@@ -4,11 +4,6 @@ test_that('AbundanceData validation works', {
   load(testOTU_path)
 
   df <- testOTU
-  df[,1][10] <- -10
-  expect_error(AbundanceData(
-              name = 'test',
-              data = df,
-              recordIdColumn = c('entity.SampleID')))
 
   # Handle negatives more gracefully
   df_neg <- df
@@ -17,6 +12,19 @@ test_that('AbundanceData validation works', {
   expect_error(microbiomeComputations::AbundanceData(
               data = df_neg,
               recordIdColumn = c('entity.SampleID')))
+
+  # Ensure funky ids do not throw off our negative value check (see issue #30)
+  df[2, 1] <- "__id__"
+  
+  abundance_collection <- AbundanceData(
+    name = 'test',
+    data = df,
+    recordIdColumn = 'entity.SampleID'
+  )
+  
+  abundances <- getAbundances(abundance_collection)
+  expect_equal(nrow(abundances), nrow(df))
+  expect_equal(ncol(abundances), ncol(df))
 
 })
 


### PR DESCRIPTION
Resolves #30 

This PR does two things
1. Removes the id columns from the negative value check. We shouldn't care if the strings are < "0"
2. Cleans up the negative value log and tests so they're more concise and functional.