### PR TITLE
require using updated veupathUtils version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     SpiecEasi,
     stringi,
     vegan,
-    veupathUtils,
+    veupathUtils (>= 2.7.0),
 Depends:
     R (>= 2.10)
 Remotes:


### PR DESCRIPTION
Previously, the installation of microbiomeComputations was unintneionally downgrading the veuapthUtils version.