### PR TITLE
Rationalise deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: microbiomeComputations
 Title: Compute Results for Microbiome Analyses
-Version: 5.1.7
+Version: 5.2.0
 Authors@R: 
     c(person(given = "Danielle",
            family = "Callan",
@@ -20,15 +20,14 @@ Imports:
     purrr,
     Rcpp (>= 0.11.0),
     S4Vectors,
-    SpiecEasi (>= 1.0.7),
     stringi,
     vegan,
     mbioUtils (>= 0.1.0)
 Depends:
     R (>= 2.10)
 Remotes:
-    microbiomeDB/mbioUtils,
-    zdk123/SpiecEasi@v1.0.7
+    microbiomeDB/mbioUtils@vX.Y.Z,
+    bioc::3.22/Maaslin2
 biocViews:
 LinkingTo: Rcpp
 URL: https://github.com/microbiomeDB/microbiomeComputations, https://microbiomedb.github.io/microbiomeComputations/
@@ -39,6 +38,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
+BiocViews:
 Suggests: 
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
 Depends:
     R (>= 2.10)
 Remotes:
-    microbiomeDB/mbioUtils@vX.Y.Z,
+    microbiomeDB/mbioUtils,
     bioc::3.22/Maaslin2
 biocViews:
 LinkingTo: Rcpp


### PR DESCRIPTION
This draft PR is provisional based on adding

```
Remotes:
  zdk123/SpiecEasi@v1.0.7
```

to mbioUtils/DESCRIPTION

I'm pretty sure this is where the dependency should be declared, not here.

However. I'm going to avoid the whole mbioUtils/veupathUtils clash of the titans for now.